### PR TITLE
Deprecate auto-detect port

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Refactoring
+
+* Deprecate auto-detect port. Since now full `bugzilla_url` with scheme is required.
+
 ## 0.2.0 (2018-05-15)
 ### New features
 * New method `BugzillaHelper#bug_exists?`

--- a/lib/onlyoffice_bugzilla_helper.rb
+++ b/lib/onlyoffice_bugzilla_helper.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'net/http'
 require 'uri'
 require 'onlyoffice_bugzilla_helper/bug_data'
+require 'onlyoffice_bugzilla_helper/networking'
 require 'onlyoffice_bugzilla_helper/version'
 
 # Helper for bugzilla, used in QA
@@ -10,11 +11,12 @@ module OnlyofficeBugzillaHelper
   # Class to check bugzilla via http
   class BugzillaHelper
     include BugData
+    include Networking
     attr_reader :url
 
-    def initialize(bugzilla_url: 'bugzilla.onlyoffice.com',
+    def initialize(bugzilla_url: 'https://bugzilla.onlyoffice.com',
                    api_key: BugzillaHelper.read_token)
-      @url = bugzilla_url
+      @uri = URI.parse(bugzilla_url)
       @key = api_key
       @show_bug_path = '/show_bug.cgi'
       @show_bug_param = 'id'
@@ -57,18 +59,11 @@ module OnlyofficeBugzillaHelper
     end
 
     # @param bug_id [Integer] id of bug
-    # @param port [Integer] port of server
     # @return [Net::HTTPResponse] result of request
-    def get_bug_result(bug_id, port)
-      Net::HTTP.start(url, port, use_ssl: (port == 443)) do |http|
+    def get_bug_result(bug_id)
+      Net::HTTP.start(@uri.host, @uri.port, use_ssl: use_ssl?) do |http|
         http.get(bug_url(bug_id))
       end
-    end
-
-    # @param response [Net::HTTPResponse] to check
-    # @return [Boolean] is response - redirect
-    def response_redirect?(response)
-      response.header['location']
     end
   end
 end

--- a/lib/onlyoffice_bugzilla_helper/bug_data.rb
+++ b/lib/onlyoffice_bugzilla_helper/bug_data.rb
@@ -5,8 +5,7 @@ module OnlyofficeBugzillaHelper
     # @param bug_id [String, Integer] id of bug
     # @return [JSON] data
     def bug_data(bug_id)
-      res = get_bug_result(bug_id, 80)
-      res = get_bug_result(bug_id, 443) if response_redirect?(res)
+      res = get_bug_result(bug_id)
       JSON.parse(res.body)['bugs'].first
     end
 

--- a/lib/onlyoffice_bugzilla_helper/networking.rb
+++ b/lib/onlyoffice_bugzilla_helper/networking.rb
@@ -1,0 +1,11 @@
+module OnlyofficeBugzillaHelper
+  # Code for networking
+  module Networking
+    private
+
+    # @return [True, False] is ssl shold be used
+    def use_ssl?
+      @uri.scheme == 'https'
+    end
+  end
+end


### PR DESCRIPTION
Since now full `bugzilla_url` with scheme is required.