### PR TITLE
Fix `BugzillaHelper#bug_exists?` after removing Testopia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix `BugzillaHelper#bug_exists?` after removing Testopia
+
 ## 0.3.2 (2020-04-29)
 
 * Fix forgotten version bump

--- a/lib/onlyoffice_bugzilla_helper/bug_data.rb
+++ b/lib/onlyoffice_bugzilla_helper/bug_data.rb
@@ -24,7 +24,7 @@ module OnlyofficeBugzillaHelper
     def bug_exists?(bug_id)
       bug_status(bug_id)
       true
-    rescue JSON::ParserError
+    rescue JSON::ParserError, NoMethodError
       false
     end
   end


### PR DESCRIPTION
Seems before Testopia was remove yesterday
result of `bug_data` for non-existing bug was not
`Net::HTTPNotFound` as now, so fix it